### PR TITLE
Add Claude Code slash commands and .claudeignore

### DIFF
--- a/.claude/commands/backup-check.md
+++ b/.claude/commands/backup-check.md
@@ -1,0 +1,7 @@
+Check the health of all backup systems. Run these checks and report a summary:
+
+1. **Datastore exports**: Run `gsutil ls gs://demographics_data_export/ | tail -5` to show the most recent weekly backups.
+2. **Snapshot coverage**: Describe how to check via `GET /tasks/snapshotCoverage` (requires admin key header).
+3. **BigQuery freshness**: Run `bq query --use_legacy_sql=false 'SELECT MAX(date) as latest_date, COUNT(*) as total_rows FROM demographics.responses'` to check the latest export date.
+
+Report a table summarizing: backup type, last run date, and status (OK/STALE/MISSING).

--- a/.claude/commands/data-check.md
+++ b/.claude/commands/data-check.md
@@ -1,6 +1,6 @@
 Check data integrity by comparing Datastore and BigQuery for recent dates.
 
-Run a BigQuery query to check the last 7 days of data:
+1. **BigQuery side**: Run a query to check the last 7 days:
 
 ```
 bq query --use_legacy_sql=false '
@@ -12,9 +12,18 @@ ORDER BY date DESC
 '
 ```
 
+2. **Datastore vs BigQuery comparison**: Call the app's comparison endpoint to check for discrepancies. This requires the admin key header:
+
+```
+curl -H "X-Task-Admin-Key: <admin-key>" "https://demographics.mturk-tracker.com/tasks/compareDatastoreBigQuery?from=<7-days-ago>&to=<today>"
+```
+
+If the endpoint is not accessible, note that only the BigQuery side was checked.
+
 Report:
 - Whether data is flowing daily (expect responses every day)
 - Any days with zero or unusually low response counts (typical range: 50-200/day)
+- Any discrepancies between Datastore and BigQuery counts
 - The most recent date with data
 
 If there are gaps, suggest using the `/tasks/smartRestoreFromBigQuery` endpoint to backfill.

--- a/.claude/commands/data-check.md
+++ b/.claude/commands/data-check.md
@@ -4,11 +4,11 @@ Check data integrity by comparing Datastore and BigQuery for recent dates.
 
 ```
 bq query --use_legacy_sql=false '
-SELECT date, COUNT(*) as responses
+SELECT DATE(date) as day, COUNT(*) as responses
 FROM demographics.responses
-WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
-GROUP BY date
-ORDER BY date DESC
+WHERE DATE(date) >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
+GROUP BY day
+ORDER BY day DESC
 '
 ```
 

--- a/.claude/commands/data-check.md
+++ b/.claude/commands/data-check.md
@@ -1,0 +1,20 @@
+Check data integrity by comparing Datastore and BigQuery for recent dates.
+
+Run a BigQuery query to check the last 7 days of data:
+
+```
+bq query --use_legacy_sql=false '
+SELECT date, COUNT(*) as responses
+FROM demographics.responses
+WHERE date >= DATE_SUB(CURRENT_DATE(), INTERVAL 7 DAY)
+GROUP BY date
+ORDER BY date DESC
+'
+```
+
+Report:
+- Whether data is flowing daily (expect responses every day)
+- Any days with zero or unusually low response counts (typical range: 50-200/day)
+- The most recent date with data
+
+If there are gaps, suggest using the `/tasks/smartRestoreFromBigQuery` endpoint to backfill.

--- a/.claude/commands/deploy.md
+++ b/.claude/commands/deploy.md
@@ -1,0 +1,10 @@
+Deploy the app to Google App Engine.
+
+Steps:
+1. Build with `JAVA_TOOL_OPTIONS="" mvn clean install -Dmaven.resolver.transport=wagon -B`
+2. Deploy the app: `mvn appengine:deploy -B -Dapp.deploy.promote=true`
+3. Deploy cron jobs: `gcloud app deploy src/main/appengine/cron.yaml --project=mturk-demographics --quiet`
+4. Deploy Datastore indexes: `gcloud app deploy src/main/appengine/index.yaml --project=mturk-demographics --quiet`
+5. Verify the deployment by checking `https://demographics.mturk-tracker.com/actuator/health`
+
+If any step fails, stop and report the error. Do not proceed to the next step.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,6 +1,6 @@
-Review the current branch's changes against master for a pull request.
+Review the current branch's changes against the default branch for a pull request.
 
-Run `git diff master...HEAD` and review all changes for:
+Determine the default branch by running `git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'` (typically `master`). Then run `git diff <default-branch>...HEAD` and review all changes for:
 
 1. **Security**: OWASP top 10 issues (injection, XSS, broken auth). Check that no secrets or credentials are committed.
 2. **Jakarta namespace**: Flag any `javax.*` imports — this project uses `jakarta.*` (Spring Boot 3.x).

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,0 +1,12 @@
+Review the current branch's changes against master for a pull request.
+
+Run `git diff master...HEAD` and review all changes for:
+
+1. **Security**: OWASP top 10 issues (injection, XSS, broken auth). Check that no secrets or credentials are committed.
+2. **Jakarta namespace**: Flag any `javax.*` imports — this project uses `jakarta.*` (Spring Boot 3.x).
+3. **Objectify patterns**: Verify correct use of `@Entity`, `@Index`, `@Cache` annotations. Ensure new queries have matching indexes in `index.yaml`.
+4. **Spring Boot conventions**: Proper use of `@RestController`, `@Service`, `@Autowired`. Check error handling via `RestResponseEntityExceptionHandler`.
+5. **Frontend**: If Vue/JS files changed, verify CDN-only approach (no npm/node). Check for XSS in template rendering.
+6. **Data model**: If entities changed, check backward compatibility with existing Datastore data.
+
+Report findings grouped by severity: CRITICAL, WARNING, INFO.

--- a/.claude/commands/review-pr.md
+++ b/.claude/commands/review-pr.md
@@ -1,6 +1,6 @@
 Review the current branch's changes against the default branch for a pull request.
 
-Determine the default branch by running `git symbolic-ref refs/remotes/origin/HEAD | sed 's@^refs/remotes/origin/@@'` (typically `master`). Then run `git diff <default-branch>...HEAD` and review all changes for:
+Determine the base branch: try `git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's@^refs/remotes/origin/@@'`, falling back to `master` if that fails. Then run `git diff <base-branch>...HEAD` and review all changes for:
 
 1. **Security**: OWASP top 10 issues (injection, XSS, broken auth). Check that no secrets or credentials are committed.
 2. **Jakarta namespace**: Flag any `javax.*` imports — this project uses `jakarta.*` (Spring Boot 3.x).

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,31 @@
+# Build output
+target/
+build/
+out/
+dist/
+*.class
+*.jar
+*.war
+
+# Encrypted credentials (binary, not useful as context)
+*.enc
+
+# Minified assets
+*.min.js
+*.min.css
+
+# Dependencies
+node_modules/
+bower_components/
+
+# IDE
+.idea/
+.vscode/
+*.iml
+
+# GCP local
+.gcloud/
+local_db.bin
+
+# Cloud SDK installed by hooks
+/tmp/


### PR DESCRIPTION
Add custom slash commands for common workflows:
- /deploy: standardized App Engine deployment steps
- /review-pr: code review checklist (security, Jakarta, Objectify)
- /backup-check: verify backup health across GCS/BigQuery/snapshots
- /data-check: compare recent Datastore vs BigQuery data integrity

Add .claudeignore to exclude build output, binaries, and encrypted
credential files from Claude Code context.

https://claude.ai/code/session_01AAFZAagBARPM5xjUZJe5Xa